### PR TITLE
Fix 404 error on Rank-endpoint

### DIFF
--- a/CotdQualifierRankWeb/Controllers/RankController.cs
+++ b/CotdQualifierRankWeb/Controllers/RankController.cs
@@ -19,6 +19,8 @@ namespace CotdQualifierRankWeb.Controllers
         NadeoCompetitionService _nadeoCompeitionService { get; set; }
         CompetitionService _competitionService { get; set; }
 
+        public static readonly int TimeoutInterval = 500;
+
         public RankController(CotdContext context, NadeoApiController nadeoApiController, NadeoCompetitionService nadeoCompetitionService, CompetitionService competitionService)
         {
             _context = context;
@@ -53,15 +55,6 @@ namespace CotdQualifierRankWeb.Controllers
                 Time = time,
                 Rank = rank,
             });
-            //return Ok(new
-            //{
-            //    mapUid,
-            //    competitionId = cotd.NadeoCompetitionId,
-            //    challengeId = cotd.NadeoChallengeId,
-            //    date = cotd.Date,
-            //    time,
-            //    rank,
-            //});
         }
 
         public int FindRankInLeaderboard(Competition cotd, int time)
@@ -141,7 +134,6 @@ namespace CotdQualifierRankWeb.Controllers
                         }
                         cotd = await FetchCompetition(nadeoCompetition, mapUid, mapTotdDate);
                     }
-                    _competitionService.AddCompetition(cotd);
                     return cotd;
                 }
                 catch (Exception e)
@@ -168,8 +160,8 @@ namespace CotdQualifierRankWeb.Controllers
                     fullLeaderboard.AddRange(records);
                 }
 
-                // Sleep for 0.5 seconds to not DOS the Nadeo API
-                Thread.Sleep(500);
+                // Sleep for a little while to not overload the Nadeo API
+                Thread.Sleep(TimeoutInterval);
             }
 
             return fullLeaderboard;
@@ -217,7 +209,10 @@ namespace CotdQualifierRankWeb.Controllers
                                         ).Date == mapTotdDate.Date);
 
                         // when we find it, fetch the leaderboard and store it in the db
-                        return competition;
+                        if (competition is not null)
+                        {
+                            return competition;
+                        }
                     }
                     catch (Exception e)
                     {
@@ -225,8 +220,8 @@ namespace CotdQualifierRankWeb.Controllers
                         return null;
                     }
                 }
-                // Sleep for 0.5 seconds to not DOS the Nadeo API
-                Thread.Sleep(500);
+                // Sleep for a little while to not overload the Nadeo API
+                Thread.Sleep(TimeoutInterval);
             }
             return null;
         }

--- a/CotdQualifierRankWeb/Pages/Index.cshtml
+++ b/CotdQualifierRankWeb/Pages/Index.cshtml
@@ -26,6 +26,7 @@
                 @Html.DisplayNameFor(model => model.Competitions[0].NadeoMapUid)
             </th>
             <th></th>
+            <th></th>
         </tr>
     </thead>
     <tbody>
@@ -48,6 +49,14 @@
             </td>
             <td>
                 <a asp-page="./Details" asp-route-id="@Model.Competitions[i].Id">Details</a>
+            </td>
+            <td>
+                <form method="post" asp-page-handler="Delete" asp-route-id="@Model.Competitions[i].Id"
+                      onsubmit="return confirm('Are you sure you want to delete this Leaderboard?')">
+                    <button class="btn-danger">
+                        Delete
+                    </button>
+                </form>
             </td>
         </tr>
 }

--- a/CotdQualifierRankWeb/Pages/Index.cshtml.cs
+++ b/CotdQualifierRankWeb/Pages/Index.cshtml.cs
@@ -22,5 +22,11 @@ namespace CotdQualifierRankWeb.Pages
             Competitions = compsAndPlayerCounts.Comps;
             CompetitionPlayerCounts = compsAndPlayerCounts.PlayerCounts;
         }
+
+        public void OnPostDelete(int id)
+        {
+            _competitionService.DeleteCompetition(id);
+            OnGet();
+        }
     }
 }

--- a/CotdQualifierRankWeb/Services/CompetitionService.cs
+++ b/CotdQualifierRankWeb/Services/CompetitionService.cs
@@ -46,5 +46,15 @@ namespace CotdQualifierRankWeb.Services
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
             return (Comps: competitions, PlayerCounts: competitionPlayerCounts);
         }
+
+        public void DeleteCompetition(int id)
+        {
+            var competition = _context.Competitions.Include(c => c.Leaderboard).FirstOrDefault(c => c.Id == id);
+            if (competition is not null)
+            {
+                _context.Competitions.Remove(competition);
+                _context.SaveChanges();
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #3 

- Fix 404 error when getting rank for leaderboard not yet downloaded from Nadeo.
  - Reason: Forgot to check if there was a match in the first request when finding the CompetitionId
  - Solution: Add a check to only return if there was a match
- Add option to delete a competition on the index page (mostly for testing purposes)
- Remove commented out code
- Add constant in RankController for API throttling