### PR TITLE
Fix details view on empty leaderboard

### DIFF
--- a/CotdQualifierRankWeb/Pages/Details.cshtml
+++ b/CotdQualifierRankWeb/Pages/Details.cshtml
@@ -65,6 +65,10 @@
                     </dd>
                 </dl>
             </div>
+
+            @if (Model.Competition.Leaderboard is not null && 
+                Model.Competition.Leaderboard.Count > 0)
+            {
             <div class="col-md-4">
                 <div>
                     <form method="post" asp-page-handler="PB" asp-route-id="@Model.Competition.Id">
@@ -105,10 +109,14 @@
                     }
                 </div>
             </div>
+            }
         </div>
     </div>
 </div>
 
+@if (Model.Competition.Leaderboard is not null &&
+    Model.Competition.Leaderboard.Count > 0)
+{
 <nav aria-label="Page navigation">
     <ul class="pagination">
         <li class="page-item">
@@ -266,3 +274,4 @@
         </div>
     </div>
 </div>
+}

--- a/CotdQualifierRankWeb/Pages/Details.cshtml.cs
+++ b/CotdQualifierRankWeb/Pages/Details.cshtml.cs
@@ -71,7 +71,10 @@ namespace CotdQualifierRankWeb.Pages
 
         private void CalculateStatistics()
         {
-            if (Competition is null || Competition.Leaderboard is null || PaginatedLeaderboard is null)
+            if (Competition is null ||
+                Competition.Leaderboard is null ||
+                PaginatedLeaderboard is null ||
+                Competition.Leaderboard.Count == 0)
             {
                 return;
             }


### PR DESCRIPTION
- Add conditional renders on affected components to only render when leaderboard has more than 0 entries