### PR TITLE
26 monthwise pagination

### DIFF
--- a/CotdQualifierRankWeb/Pages/Index.cshtml
+++ b/CotdQualifierRankWeb/Pages/Index.cshtml
@@ -1,14 +1,72 @@
 @page
+@using CotdQualifierRankWeb.Utils
 @model IndexModel
 
 @{
     ViewData["Title"] = "Index";
 }
 
-<h1>Recent Cup of the Days</h1>
+<h1>Recent Cup of the Days @(Model.FilterAnomalous ? "" : "- " + Model.GetPageMonthDateTime().ToMonthAndYearString())</h1>
 @if (Model.FilterAnomalous)
 {
     <h2>Anomalous Leaderboards <span title="Anomalous COTDs are those with empty or otherwise incomplete leaderboards">&#9432;</span></h2>
+}
+
+@if (!Model.FilterAnomalous)
+{
+<div class="index-pagination-container">
+    <div class="filter-container"></div>
+    <nav aria-label="Page navigation">
+        <ul class="pagination">
+            @if (Model.GetPageMonthDateTime() != Model.OldestMonth)
+            {
+                <li class="page-item">
+                    <a
+                        asp-route-pageMonth="@Model.OldestMonth.ToPageMonthString()"
+                        asp-route-filterAnomalous="@Model.FilterAnomalous" 
+                        asp-page="./Index"
+                        class="page-link page-link-dark"
+                    >
+                        <pre class="m-0">&lt;&lt;</pre>
+                    </a>
+                </li>
+                <li class="page-item">
+                        <a
+                            asp-route-pageMonth="@Model.NewPageMonth(-1)"
+                            asp-route-filterAnomalous="@Model.FilterAnomalous" 
+                            asp-page="./Index"
+                            class="page-link page-link-dark"
+                        >
+                            <pre class="m-0">&lt;&nbsp;@Model.NewPageMonth(-1, true)</pre>
+                        </a>
+                </li>
+            }
+            @if (Model.GetPageMonthDateTime() != Model.NewestMonth)
+            {
+                <li class="page-item">
+                    <a
+                        asp-route-pageMonth="@Model.NewPageMonth(1)"
+                        asp-route-filterAnomalous="@Model.FilterAnomalous" 
+                        asp-page="./Index"
+                        class="page-link page-link-dark"
+                    >
+                        <pre class="m-0">@Model.NewPageMonth(1, true)&nbsp;&gt;</pre>
+                    </a>
+                </li>
+                <li class="page-item">
+                    <a
+                        asp-route-pageMonth="@Model.NewestMonth.ToPageMonthString()"
+                        asp-route-filterAnomalous="@Model.FilterAnomalous" 
+                        asp-page="./Index"
+                        class="page-link page-link-dark"
+                    >
+                        <pre class="m-0">&gt;&gt;</pre>
+                    </a>
+                </li>
+            }
+        </ul>
+    </nav>
+</div>
 }
 
 <table class="table table-borderless table-striped" style="color:#cfcfcf">
@@ -70,150 +128,17 @@
     </tbody>
 </table>
 
-<div class="index-pagination-container">
-    <div class="filter-container"></div>
-    <nav aria-label="Page navigation">
-        <ul class="pagination">
-            <li class="page-item">
-                @if (Model.PageNo > 1)
-                {
-                    <a
-                        asp-route-pageNo="@(Model.PageNo-1)"
-                        asp-route-filterAnomalous="@Model.FilterAnomalous" 
-                        asp-page="./Index"
-                        class="page-link page-link-dark"
-                    >
-                        <pre class="m-0"><code class="pagination-code" aria-label="left">&lt;</code></pre>
-                    </a>
-                }
-                else
-                {
-                    <a class="page-link disabled page-link-disabled">
-                        <pre class="m-0"><code class="pagination-code" aria-label="left">&lt;</code></pre>
-                    </a>
-                }
-            </li>
-
-            @if (Model.PageCount < 8)
+<div class="filter-container">
+    <div class="d-flex">
+        <a asp-route-filterAnomalous="@(!Model.FilterAnomalous)">
+            @if (Model.FilterAnomalous)
             {
-                @for (int i = 0; i < Model.PageCount; i++)
-                {
-                    <li class="page-item @(Model.PageNo == i + 1 ? "active" : "")">
-                        <a
-                            asp-route-pageNo="@(i + 1)"
-                            asp-route-filterAnomalous="@Model.FilterAnomalous" 
-                            asp-page="./Index"
-                            class="page-link page-link-dark"
-                        >
-                            <pre class="m-0"><code class="pagination-code">@(i + 1)</code></pre>
-                        </a>
-                    </li>
-                }
+                <div>Show all COTDs</div>
             }
             else
             {
-                <li class="page-item @(Model.PageNo == 1 ? "active" : "")">
-                    <a
-                        asp-route-pageNo="1"
-                        asp-route-filterAnomalous="@Model.FilterAnomalous" 
-                        asp-page="./Index"
-                        class="page-link page-link-dark"
-                    >
-                        <pre class="m-0"><code class="pagination-code">1</code></pre>
-                    </a>
-                </li>
-                @if (Model.PageNo > 4)
-                {
-                    <li class="page-item">
-                        <a class="page-link page-link-dots">
-                            <code class="pagination-code">...</code>
-                        </a>
-                    </li>
-                }
-
-                var start = Math.Max(Model.PageNo - 3, 1);
-                var startLost = start - (Model.PageNo - 3);
-
-                var end = Model.PageNo < 5 ?
-                    Math.Min(Model.PageNo + 2 + startLost + 1, Model.PageCount - 1)
-                    : Math.Min(Model.PageNo + 2 + startLost, Model.PageCount - 1);
-
-                var endLost = (Model.PageNo + 3) - end;
-
-                if (Model.PageNo >= 5){
-                    start = Model.PageNo > Model.PageCount - 4 ?
-                        Math.Max(Model.PageNo - 2 - endLost - 1, 1)
-                        : Math.Max(Model.PageNo - 2 - endLost, 1);
-                }
-
-                @for (int i = start; i < end; i++)
-                {
-                    <li class="page-item @(Model.PageNo == i + 1 ? "active" : "")">
-                        <a
-                            asp-route-pageNo="@(i + 1)"
-                            asp-route-filterAnomalous="@Model.FilterAnomalous" 
-                            asp-page="./Index"
-                            class="page-link page-link-dark"
-                        >
-                            <pre class="m-0"><code class="pagination-code">@(i + 1)</code></pre>
-                        </a>
-                    </li>
-                }
-                @if (Model.PageNo < Model.PageCount - 3)
-                {
-                    <li class="page-item">
-                        <a class="page-link page-link-dots">
-                            <code class="pagination-code">...</code>
-                        </a>
-                    </li>
-                }
-                <li class="page-item @(Model.PageNo == Model.PageCount ? "active" : "")">
-                    <a
-                        asp-route-pageNo="@(Model.PageCount)"
-                        asp-route-filterAnomalous="@Model.FilterAnomalous" 
-                        asp-page="./Index"
-                        class="page-link page-link-dark"
-                    >
-                        <pre class="m-0"><code class="pagination-code">@(Model.PageCount)</code></pre>
-                    </a>
-                </li>
+                <div>Show only anomalous COTDs</div>
             }
-
-            <li class="page-item">
-                @if (Model.PageNo < Model.PageCount)
-                {
-                    <a
-                        asp-route-pageNo="@(Model.PageNo+1)"
-                        asp-route-filterAnomalous="@Model.FilterAnomalous" 
-                        asp-page="./Index"
-                        class="page-link page-link-dark"
-                    >
-                        <pre class="m-0"><code class="pagination-code" aria-label="right">&gt;</code></pre>
-                    </a>
-                }
-                else
-                {
-                    <a class="page-link disabled page-link-disabled">
-                        <pre class="m-0"><code class="pagination-code" aria-label="right">&gt;</code></pre>
-                    </a>
-                }
-            </li>
-        </ul>
-    </nav>
-
-    <div class="filter-container">
-        <div class="d-flex">
-            <a asp-route-filterAnomalous="@(!Model.FilterAnomalous)">
-                @if (Model.FilterAnomalous)
-                {
-                    <div>Show all COTDs</div>
-                }
-                else
-                {
-                    <div>Show only anomalous COTDs</div>
-                }
-            </a>&nbsp; <div title="Anomalous COTDs are those with empty or otherwise incomplete leaderboards">&#9432;</div>
-        </div>
+        </a>&nbsp; <div title="Anomalous COTDs are those with empty or otherwise incomplete leaderboards">&#9432;</div>
     </div>
 </div>
-

--- a/CotdQualifierRankWeb/Pages/Index.cshtml
+++ b/CotdQualifierRankWeb/Pages/Index.cshtml
@@ -95,7 +95,14 @@
 @for (int i = 0; i<Model.Competitions.Count;i++) {
         <tr>
             <td>
-                @Model.Competitions[i].Date.ToShortDateString()
+                @if (Model.FilterAnomalous)
+                {
+                    @Model.Competitions[i].Date.ToShortDateString()
+                }
+                else
+                {
+                    @Model.Competitions[i].Date.ToShortDayString()
+                }
             </td>
             <td>
                 @Model.CompetitionPlayerCounts[i]

--- a/CotdQualifierRankWeb/Utils/Extensions.cs
+++ b/CotdQualifierRankWeb/Utils/Extensions.cs
@@ -8,13 +8,20 @@ namespace CotdQualifierRankWeb.Utils
         {
             return date.ToString("MMMM", CultureInfo.GetCultureInfo("en-UK"));
         }
+
         public static string ToPageMonthString(this DateTime date)
         {
             return date.ToString("yyyy-MM");
         }
+
         public static string ToMonthAndYearString(this DateTime date)
         {
             return date.ToString("MMMM yyyy", CultureInfo.GetCultureInfo("en-UK"));
+        }
+
+        public static string ToShortDayString(this DateTime date)
+        {
+            return date.ToString("dd. dddd", CultureInfo.GetCultureInfo("en-UK"));
         }
     }
 }

--- a/CotdQualifierRankWeb/Utils/Extensions.cs
+++ b/CotdQualifierRankWeb/Utils/Extensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Globalization;
+
+namespace CotdQualifierRankWeb.Utils
+{
+    public static class Extensions
+    {
+        public static string ToMonthString(this DateTime date)
+        {
+            return date.ToString("MMMM", CultureInfo.GetCultureInfo("en-UK"));
+        }
+        public static string ToPageMonthString(this DateTime date)
+        {
+            return date.ToString("yyyy-MM");
+        }
+        public static string ToMonthAndYearString(this DateTime date)
+        {
+            return date.ToString("MMMM yyyy", CultureInfo.GetCultureInfo("en-UK"));
+        }
+    }
+}


### PR DESCRIPTION
Closes #26 

- Make pages show one month at a time (including empty months)
- Move page navigation to above table
- Change date format in the list view to not include month (month is shown at the top of the page)