### PR TITLE
33 additional endpoints

### DIFF
--- a/CotdQualifierRankWeb/Controllers/CompetitionsController.cs
+++ b/CotdQualifierRankWeb/Controllers/CompetitionsController.cs
@@ -1,0 +1,61 @@
+﻿using CotdQualifierRankWeb.DTOs;
+using CotdQualifierRankWeb.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CotdQualifierRankWeb.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CompetitionsController : ControllerBase
+    {
+        private CompetitionService _competitionService { get; set; }
+
+        public CompetitionsController(CompetitionService competitionService)
+        {
+            _competitionService = competitionService;
+        }
+
+        [HttpGet]
+        [Route("{mapUID}")]
+        public IActionResult GetCompetitionByMap(string mapUid)
+        {
+            var competition = _competitionService.GetCompetitionByMapUid(mapUid, false);
+
+            if (competition is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(new CompetitionDTO
+            {
+                ChallengeId = competition.NadeoChallengeId,
+                CompetitionId = competition.NadeoCompetitionId,
+                Date = competition.Date,
+                MapUid = competition.NadeoMapUid,
+            });
+        }
+
+        //[HttpGet]
+        //[Route("{mapUID}/leaderboard")]
+
+        [HttpGet]
+        [Route("{competitionId:int}")]
+        public IActionResult GetCompetitionByCompetitionId(int competitionId)
+        {
+            var competition = _competitionService.GetCompetition(competitionId);
+
+            if (competition is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(new CompetitionDTO
+            {
+                ChallengeId = competition.NadeoChallengeId,
+                CompetitionId = competition.NadeoCompetitionId,
+                Date = competition.Date,
+                MapUid = competition.NadeoMapUid,
+            });
+        }
+    }
+}

--- a/CotdQualifierRankWeb/Controllers/CompetitionsController.cs
+++ b/CotdQualifierRankWeb/Controllers/CompetitionsController.cs
@@ -35,14 +35,41 @@ namespace CotdQualifierRankWeb.Controllers
             });
         }
 
-        //[HttpGet]
-        //[Route("{mapUID}/leaderboard")]
+        [HttpGet]
+        [Route("{mapUID}/leaderboard")]
+        public IActionResult GetCompetitionLeaderboardByMapUid(string mapUid)
+        {
+            var competition = _competitionService.GetCompetitionByMapUid(mapUid, true);
+
+            if (competition is null || competition.Leaderboard is null)
+            {
+                return NotFound();
+            }
+
+            var leaderboard = competition.Leaderboard.OrderBy(r => r.Time).Select(r => r.Time);
+            return Ok(leaderboard);
+        }
+
+        [HttpGet]
+        [Route("{competitionId:int}/leaderboard")]
+        public IActionResult GetCompetitionLeaderboardByChallengeId(int competitionId)
+        {
+            var competition = _competitionService.GetCompetition(competitionId, true);
+
+            if (competition is null || competition.Leaderboard is null)
+            {
+                return NotFound();
+            }
+
+            var leaderboard = competition.Leaderboard.OrderBy(r => r.Time).Select(r => r.Time);
+            return Ok(leaderboard);
+        }
 
         [HttpGet]
         [Route("{competitionId:int}")]
         public IActionResult GetCompetitionByCompetitionId(int competitionId)
         {
-            var competition = _competitionService.GetCompetition(competitionId);
+            var competition = _competitionService.GetCompetition(competitionId, false);
 
             if (competition is null)
             {

--- a/CotdQualifierRankWeb/Controllers/MapsController.cs
+++ b/CotdQualifierRankWeb/Controllers/MapsController.cs
@@ -1,0 +1,30 @@
+﻿using CotdQualifierRankWeb.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CotdQualifierRankWeb.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class MapsController : ControllerBase
+    {
+        private CompetitionService _competitionService { get; set; }
+
+        public MapsController(CompetitionService competitionService)
+        {
+            _competitionService = competitionService;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetMapUids()
+        {
+            var maps = await _competitionService.GetMapsUids();
+
+            if (maps is null)
+            {
+                return NotFound();
+            }
+
+            return Ok(maps);
+        }
+    }
+}

--- a/CotdQualifierRankWeb/Controllers/RankController.cs
+++ b/CotdQualifierRankWeb/Controllers/RankController.cs
@@ -44,7 +44,7 @@ namespace CotdQualifierRankWeb.Controllers
 
             var rank = FindRankInLeaderboard(cotd, time);
 
-            return Ok(new GetRankDTO
+            return Ok(new RankDTO
             {
                 MapUid = mapUid,
                 CompetitionId = cotd.NadeoCompetitionId,

--- a/CotdQualifierRankWeb/DTOs/CompetitionDTO.cs
+++ b/CotdQualifierRankWeb/DTOs/CompetitionDTO.cs
@@ -1,0 +1,10 @@
+﻿namespace CotdQualifierRankWeb.DTOs
+{
+    public class CompetitionDTO
+    {
+        public int CompetitionId { get; set; } = 0;
+        public int ChallengeId { get; set; } = 0;
+        public string? MapUid { get; set; } = default!;
+        public DateTime Date { get; set; } = default!;
+    }
+}

--- a/CotdQualifierRankWeb/DTOs/RankDTO.cs
+++ b/CotdQualifierRankWeb/DTOs/RankDTO.cs
@@ -1,6 +1,6 @@
 ﻿namespace CotdQualifierRankWeb.DTOs
 {
-    public class GetRankDTO
+    public class RankDTO
     {
         public string MapUid { get; set; } = default!;
         public int CompetitionId { get; set; } = 0;

--- a/CotdQualifierRankWeb/Pages/Details.cshtml.cs
+++ b/CotdQualifierRankWeb/Pages/Details.cshtml.cs
@@ -131,9 +131,9 @@ namespace CotdQualifierRankWeb.Pages
             if (response is OkObjectResult okObjectResult)
             {
                 var content = okObjectResult.Value;
-                if (content is GetRankDTO getRankDTO)
+                if (content is RankDTO rankDTO)
                 {
-                    TempData["Rank"] = getRankDTO.Rank;
+                    TempData["Rank"] = rankDTO.Rank;
                     TempData["Time"] = Time;
                 }
             }

--- a/CotdQualifierRankWeb/Services/CompetitionService.cs
+++ b/CotdQualifierRankWeb/Services/CompetitionService.cs
@@ -25,8 +25,14 @@ namespace CotdQualifierRankWeb.Services
                 .FirstOrDefault(c => c.NadeoMapUid == mapUid);
         }
 
-        public Competition? GetCompetition(int competitionId)
+        public Competition? GetCompetition(int competitionId, bool includeLeaderboard = true)
         {
+            if (includeLeaderboard)
+            {
+                return _context.Competitions
+                    .Include(c => c.Leaderboard)
+                    .FirstOrDefault(c => c.NadeoCompetitionId == competitionId);
+            }
             return _context.Competitions
                 .FirstOrDefault(c => c.NadeoCompetitionId == competitionId);
         }

--- a/CotdQualifierRankWeb/Services/CompetitionService.cs
+++ b/CotdQualifierRankWeb/Services/CompetitionService.cs
@@ -13,9 +13,22 @@ namespace CotdQualifierRankWeb.Services
             _context = context;
         }
 
-        public Competition? GetCompetitionByMapUid(string mapUid)
+        public Competition? GetCompetitionByMapUid(string mapUid, bool includeLeaderboard = true)
         {
-            return _context.Competitions.Include(c => c.Leaderboard).FirstOrDefault(c => c.NadeoMapUid == mapUid);
+            if (includeLeaderboard)
+            {
+                return _context.Competitions
+                    .Include(c => c.Leaderboard)
+                    .FirstOrDefault(c => c.NadeoMapUid == mapUid);
+            }
+            return _context.Competitions
+                .FirstOrDefault(c => c.NadeoMapUid == mapUid);
+        }
+
+        public Competition? GetCompetition(int competitionId)
+        {
+            return _context.Competitions
+                .FirstOrDefault(c => c.NadeoCompetitionId == competitionId);
         }
 
         public void AddCompetition(Competition? competition)
@@ -87,6 +100,15 @@ namespace CotdQualifierRankWeb.Services
                 _context.Competitions.Remove(competition);
                 _context.SaveChanges();
             }
+        }
+
+        public async Task<List<string?>> GetMapsUids()
+        {
+            return await _context.Competitions
+                .Where(c => c.NadeoMapUid != null)
+                .OrderBy(c => c.Date)
+                .Select(c => c.NadeoMapUid)
+                .ToListAsync();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -129,13 +129,12 @@ curl -X GET http://localhost:5000/api/rank/ae262K904I12Kbj_AaBGeTqE1F0/49302
 - **URL**: `/api/maps`
 - **Method**: GET
 - **Description**: Returns a list of MapUids for all COTD leaderboards that are
-  currently in the server's database. New TOTDs are not automatically added
-  to the server's database and are fetched from Nadeo on a JIT basis.
-  I.e., when that data i needed. When qualifying session from a COTD is fetched
-  from Nadeo, the track's MapUid is added to the database and will then be
-  returned as part of this list.
-
-  The the list is sorted by each track's date (ascending)
+  currently in the server's database, sorted by COTD date.
+  New TOTDs are not automatically added to the server's database and are
+  fetched from Nadeo on a JIT basis. I.e. competition and map data is only
+  fetched from Nadeo when that data is needed. When qualifying session from a
+  COTD is fetched from Nadeo, the track's MapUid is added to the database and
+  will then be returned as part of this list.  
 
 **Example Request**:
 
@@ -192,7 +191,11 @@ curl -X GET http://localhost:5000/api/competitions/9447
 - **URL**: `/api/competitions/{mapUid|competitionId}/leaderboard`
 - **Method**: GET
 - **Description**: Returns the leaderboard from the qualifying session in a
-  COTD given the cup's CompetitionId or the associated track's MapUid
+  COTD given the cup's CompetitionId or the associated track's MapUid.  
+  A normal COTD normally has somewhere between 1000 and 5000 players, usually
+  depending on how recent it was. E.g. COTDs from 2020 saw around 1.5k players
+  while COTDs after console release regularly contain upwards of 3k players.
+  Expect the size of the returned list to in this range.
 - **Values**:
   - `mapUid (str)`: The UID of any TOTD. If the associated COTD competition's
     data has not yet been fetched from Nadeo by the server, no data is returned.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ publicly available or integrated with an accompanying
     - [The Decentralised Approach](#the-decentralised-approach)
     - [The Centralised Approach](#the-centralised-approach)
   - [API](#api)
-    - [Rank Endpoint](#rank-endpoint)
+    - [Rank](#rank)
+    - [Maps](#maps)
+    - [Competitions](#competitions)
+    - [Qualifying Leaderboard](#qualifying-leaderboard)
   - [Website](#website)
   - [Setup Guide](#setup-guide)
     - [Prerequisites](#prerequisites)
@@ -80,18 +83,28 @@ possibly pay to keep the server running.
 
 ## API
 
-The API has a single endpoint designed for use with the 
-[COTD Qualifier Rank](https://github.com/haakon8855/COTD-qualifier-rank)
-plugin. 
+The API contains several endpoints serving data related to COTDs (competitions)
+and COTD leaderboards (challenges). These include endpoints for competition
+metadata, TOTD MapUids, qualifier rank and qualifier leaderboards.
 
-### Rank Endpoint
+The Rank endpoint is considered the main use-case of this API, providing the
+rank for a given time on a specied TOTD as if that time was driven during the 
+COTD 15-minute qualifying session. This endpoint is made to accompany the
+[COTD Qualifier Rank](https://github.com/haakon8855/COTD-qualifier-rank)
+plugin (WIP). 
+
+The following is a list of the available endpoints and details about them.
+
+### Rank
 - **URL**: `/api/rank/{mapUid}/{time}`
 - **Method**: GET
 - **Description**: Returns the seeding/rank of the given time
   on the given MapUID 
 - **Values**:
-  - `mapUid`: The UID of any map. If the map is not a TOTD or was TOTD prior to 02.11.2020, no data is returned.
-  - `time`: The time in milliseconds for which a rank is returned (e.g. your current PB on a TOTD).
+  - `mapUid (str)`: The UID of any TOTD. If the associated COTD competition's
+    data has not yet been fetched from Nadeo by the server, no data is returned.
+  - `time (int)`: The time in milliseconds for which a rank is returned
+    (e.g. your current PB on the track).
 
 **Example Request**:
 
@@ -110,6 +123,104 @@ curl -X GET http://localhost:5000/api/rank/ae262K904I12Kbj_AaBGeTqE1F0/49302
     "time": 49302,
     "rank": 4079
 }
+```
+
+### Maps
+- **URL**: `/api/maps`
+- **Method**: GET
+- **Description**: Returns a list of MapUids for all COTD leaderboards that are
+  currently in the server's database. New TOTDs are not automatically added
+  to the server's database and are fetched from Nadeo on a JIT basis.
+  I.e., when that data i needed. When qualifying session from a COTD is fetched
+  from Nadeo, the track's MapUid is added to the database and will then be
+  returned as part of this list.
+
+  The the list is sorted by each track's date (ascending)
+
+**Example Request**:
+
+```shell
+curl -X GET http://localhost:5000/api/maps
+```
+
+ **Response**:
+
+```json
+[
+    "5G1WTldWDF810zEiS5dxiS2DtMj",
+    "1pmNdxhn5SrE82rh4EafPIxg7y7",
+    "IWCPdbCtlaYUWCVfWxDads9dsc",
+    ...
+    "JQkYS9BcGzbl67hu5PBdyIDcWUl",
+    "JRaHDJ_ZfSbFfGxrVw9Uk9Ai3i9"
+]
+```
+
+### Competitions
+- **URL**: `/api/competitions/{mapUid|competitionId}`
+- **Method**: GET
+- **Description**: Returns information about a COTD given its CompetitionId or
+  the MapUid of its associated track.
+- **Values**:
+  - `mapUid (str)`: The UID of any TOTD. If the associated COTD competition's
+    data has not yet been fetched from Nadeo by the server, no data is returned.
+  - `competitionId (int)`: The ID of any COTD. If the COTD competition data has not
+    yet been fetched from Nadeo by the server, no data is returned.
+
+**Example Request**:
+
+```shell
+curl -X GET http://localhost:5000/api/competitions/rbzxGFuf_dKyzxir8RgzvX5Ss65
+```
+or
+```shell
+curl -X GET http://localhost:5000/api/competitions/9447
+```
+
+ **Response**:
+
+```json
+{
+    "competitionId": 9447,
+    "challengeId": 4689,
+    "mapUid": "rbzxGFuf_dKyzxir8RgzvX5Ss65",
+    "date": "2023-09-02T19:00:00"
+}
+```
+
+### Qualifying Leaderboard
+- **URL**: `/api/competitions/{mapUid|competitionId}/leaderboard`
+- **Method**: GET
+- **Description**: Returns the leaderboard from the qualifying session in a
+  COTD given the cup's CompetitionId or the associated track's MapUid
+- **Values**:
+  - `mapUid (str)`: The UID of any TOTD. If the associated COTD competition's
+    data has not yet been fetched from Nadeo by the server, no data is returned.
+  - `competitionId (int)`: The ID of any COTD. If the COTD competition data has
+    not yet been fetched from Nadeo by the server, no data is returned.
+
+**Example Requests**:
+
+```shell
+curl -X GET http://localhost:5000/api/competitions/rbzxGFuf_dKyzxir8RgzvX5Ss65/leaderboard
+```
+or
+```shell
+curl -X GET http://localhost:5000/api/competitions/9447/leaderboard
+```
+
+ **Response**:
+
+```json
+[
+    44370,
+    44440,
+    44497,
+    ...
+    197554,
+    206797,
+    247544
+]
 ```
 
 ## Website
@@ -147,7 +258,7 @@ server locally.
 ### Prerequisites
 
 To successfully run this server locally, you will need the following:
-- A Trackmania Club Access Subscription
+- An active Trackmania Club Access Subscription
 - .NET 7.0
 
 ### Install .NET
@@ -156,7 +267,8 @@ Make sure you have
 [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
 installed.
 
-To verify you have the correct version, run the following command:
+To verify you have the correct version, run the following command in the
+terminal:
 
 ```shell
 dotnet --version
@@ -199,10 +311,10 @@ and store your dedicated server account credentials inside
 with the following format:
 ```json
 {
-  "Login": "<dedicated-server-account-login>",
-  "Password": "<dedicated-server-account-password>",
-  "AccountId": "<dedicated-server-account-account-id>",
-  "UserAgent": "<your-user-agent>",
+    "Login": "<dedicated-server-account-login>",
+    "Password": "<dedicated-server-account-password>",
+    "AccountId": "<dedicated-server-account-account-id>",
+    "UserAgent": "<your-user-agent>",
 }
 ```
 You'll also need to provide a User-Agent in the credentials file,
@@ -236,4 +348,4 @@ The code in this repository is protected by the
 This project would not be possible without:
 - The Openplanet team's
   [Trackmania Web Services API Documentation](https://webservices.openplanet.dev/)
-- The Openplanet discord server
+- Numerous helpful individuals from the Openplanet discord server


### PR DESCRIPTION
Closes #33 

Added endpoints:
- /api/maps
- /api/competitions/{mapUid}
- /api/competitions/{competitionId}
- /api/competitions/{mapUid}/leaderboard
- /api/competitions/{challengeId}/leaderboard

Updated readme with documentation about new endpoints