### PR TITLE
Add queue system for rank fetching

### DIFF
--- a/CotdQualifierRankWeb/Controllers/RankController.cs
+++ b/CotdQualifierRankWeb/Controllers/RankController.cs
@@ -1,12 +1,9 @@
 ﻿using CotdQualifierRankWeb.Data;
 using CotdQualifierRankWeb.DTOs;
 using CotdQualifierRankWeb.Models;
-using CotdQualifierRankWeb.Services;
+using CotdQualifierRankWeb.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
-using System.Globalization;
-using System.Text.RegularExpressions;
 
 namespace CotdQualifierRankWeb.Controllers
 {
@@ -15,32 +12,37 @@ namespace CotdQualifierRankWeb.Controllers
     public class RankController : ControllerBase
     {
         CotdContext _context { get; set; }
-        NadeoApiController _nadeoApiController { get; set; }
-        NadeoCompetitionService _nadeoCompeitionService { get; set; }
-        CompetitionService _competitionService { get; set; }
 
-        public RankController(CotdContext context, NadeoApiController nadeoApiController, NadeoCompetitionService nadeoCompetitionService, CompetitionService competitionService)
+        public RankController(CotdContext context)
         {
             _context = context;
-            _nadeoApiController = nadeoApiController;
-            _nadeoCompeitionService = nadeoCompetitionService;
-            _competitionService = competitionService;
         }
 
         [HttpGet("{mapUid}/{time:int}")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(RankDTO))]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> GetAction(string mapUid, int time)
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        public IActionResult GetAction(string mapUid, int time)
         {
             var cotd = _context.Competitions.Include(c => c.Leaderboard).FirstOrDefault(c => c.NadeoMapUid == mapUid);
 
             if (cotd is null)
             {
-                cotd = await FetchCompetitionFromNadeo(mapUid);
-                if (cotd is null)
+                if (!QueueService.QueueContains(mapUid))
                 {
-                    return NotFound();
+                    QueueService.AddToQueue(mapUid);
                 }
+
+                int secondsToWait = 5;
+                Response.Headers.Add("Retry-After", secondsToWait.ToString());
+                return StatusCode(503,
+                    new
+                    {
+                        message = @"Requested map is either not a valid TOTD or the COTD
+                                    leaderboard is currently being fetched from
+                                    Nadeo and will be available shortly.
+                                    Please retry in " + secondsToWait.ToString() + " seconds."
+                    }
+                );
             }
 
             var rank = FindRankInLeaderboard(cotd, time);
@@ -86,154 +88,5 @@ namespace CotdQualifierRankWeb.Controllers
             return rank;
         }
 
-        [NonAction]
-        public async Task<Competition?> FetchCompetitionFromNadeo(string mapUid)
-        {
-            // get map totd info from nadeo
-            var mapResponse = await _nadeoApiController.GetTodtInfoForMap(mapUid);
-            if (mapResponse is not null)
-            {
-                var result = await mapResponse.Content.ReadAsStringAsync();
-                // get date of totd from response
-                try
-                {
-                    var mapTotdInfo = JsonConvert.DeserializeObject<NadeoMapTotdInfoDTO>(result);
-
-                    if (mapTotdInfo is null || mapTotdInfo.TotdMaps is null)
-                    {
-                        return null;
-                    }
-                    var dayOfWeek = (mapTotdInfo.TotdMaps.IndexOf(mapUid) + 1) % 7;
-                    var mapTotdDate = ISOWeek.ToDateTime(mapTotdInfo.TotdYear, mapTotdInfo.Week, (DayOfWeek)dayOfWeek);
-                    mapTotdDate = mapTotdDate.AddHours(19);
-
-                    if (mapTotdDate < new DateTime(2020, 11, 16))
-                    {
-                        return null;
-                    }
-
-                    // Check if we have a nadeocompetition with that date
-                    // If the competition name is null, we set the date to 2020-07-01 so that we will never find a match
-                    var nadeoCompetition = _nadeoCompeitionService
-                        .GetNadeoCompetitions()
-                        .FirstOrDefault(
-                            comp => NadeoCompetition.ParseDate(
-                                comp.Name is null ? "2020-07-01" : comp.Name
-                                ).Date == mapTotdDate.Date);
-
-                    Competition? cotd = null;
-                    if (nadeoCompetition is not null)
-                    {
-                        cotd = await FetchCompetition(nadeoCompetition, mapUid, mapTotdDate);
-                    }
-                    else
-                    {
-                        // If not, fetch competitions from Nadeo until we find a match
-                        nadeoCompetition = await FetchNadeoCompetition(mapUid, mapTotdDate);
-                        // When we find it, fetch the leaderboard and store it in the db
-                        if (nadeoCompetition is null)
-                        {
-                            return null;
-                        }
-                        cotd = await FetchCompetition(nadeoCompetition, mapUid, mapTotdDate);
-                    }
-                    return cotd;
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine(e.Message);
-                    return null;
-                }
-            }
-            return null;
-        }
-
-        [NonAction]
-        public async Task<List<Record>> FetchQualificationLeaderboard(NadeoCompetition nadeoCompetition, int challengeId)
-        {
-            // Fetch the qualification leaderboard
-            var fullLeaderboard = new List<Record>();
-
-            for (int i = 0; i < nadeoCompetition.NbPlayers; i += 100)
-            {
-                var leaderboardFragment = await _nadeoApiController.GetLeaderboard(challengeId, 100, i);
-
-                if (leaderboardFragment is not null && leaderboardFragment.Results is not null)
-                {
-                    var records = leaderboardFragment.Results.Select(entry => new Record { Time = entry.Score }).ToList();
-                    fullLeaderboard.AddRange(records);
-                }
-            }
-            return fullLeaderboard;
-        }
-
-        [NonAction]
-        public async Task<Competition> FetchCompetition(NadeoCompetition nadeoCompetition, string mapUid, DateTime mapTotdDate)
-        {
-            var newCompetition = new Competition();
-            newCompetition.NadeoCompetitionId = nadeoCompetition.Id;
-            newCompetition.NadeoChallengeId = await _nadeoApiController.GetChallengeId(nadeoCompetition.Id);
-            newCompetition.NadeoMapUid = mapUid;
-            newCompetition.Date = mapTotdDate;
-            newCompetition.Leaderboard = await FetchQualificationLeaderboard(nadeoCompetition, newCompetition.NadeoChallengeId);
-            _competitionService.AddCompetition(newCompetition);
-
-            return newCompetition;
-        }
-
-        [NonAction]
-        public async Task<NadeoCompetition?> FetchNadeoCompetition(string mapUid, DateTime mapTotdDate)
-        {
-            var offsetLimit = 10000;
-            int offset = 0;
-            while (offset < offsetLimit)
-            {
-                var compResponse = await _nadeoApiController.GetCompetitions(100, offset);
-                if (compResponse is not null)
-                {
-                    var compResult = await compResponse.Content.ReadAsStringAsync();
-                    try
-                    {
-                        var competitions = JsonConvert.DeserializeObject<List<NadeoCompetition>>(compResult);
-                        if (competitions is null)
-                        {
-                            return null;
-                        }
-                        if (offset == 0)
-                        {
-                            offsetLimit = competitions.First().Id;
-                        }
-
-
-                        //var cotdCompetitions = competitions.Where(comp => Regex.IsMatch(comp.Name is null ? "" : comp.Name, @"COTD 20[0-9][0-9]-[0-9][0-9]-[0-9][0-9] #1$")).ToList();
-                        var cotdCompetitions = competitions.Where(comp => Regex.IsMatch(comp.Name is null ? "" : comp.Name, @"(COTD|Cup of the Day) 20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]($| #1$)")).ToList();
-
-                        // store all competitions while searching
-                        _nadeoCompeitionService.AddNadeoCompetitions(cotdCompetitions);
-
-                        // Check if we have a nadeocompetition with that date
-                        // If the competition name is null, we set the date to 2020-07-01 so that we will never find a match
-                        var competition = cotdCompetitions
-                                .FirstOrDefault(
-                                    comp => NadeoCompetition.ParseDate(
-                                        comp.Name is null ? "2020-07-01" : comp.Name
-                                        ).Date == mapTotdDate.Date);
-
-                        // when we find it, fetch the leaderboard and store it in the db
-                        if (competition is not null)
-                        {
-                            return competition;
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine(e.Message);
-                        return null;
-                    }
-                }
-                offset += 100;
-            }
-            return null;
-        }
     }
 }

--- a/CotdQualifierRankWeb/Pages/Details.cshtml.cs
+++ b/CotdQualifierRankWeb/Pages/Details.cshtml.cs
@@ -126,7 +126,7 @@ namespace CotdQualifierRankWeb.Pages
             {
                 return RedirectToPage();
             }
-            var response = _rankController.GetAction(Competition.NadeoMapUid, Time).Result;
+            var response = _rankController.GetAction(Competition.NadeoMapUid, Time);
 
             if (response is OkObjectResult okObjectResult)
             {

--- a/CotdQualifierRankWeb/Program.cs
+++ b/CotdQualifierRankWeb/Program.cs
@@ -1,6 +1,7 @@
 using CotdQualifierRankWeb.Controllers;
 using CotdQualifierRankWeb.Data;
 using CotdQualifierRankWeb.Services;
+using CotdQualifierRankWeb.Utils;
 using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,6 +25,8 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddHostedService<LeaderboardQueueWorker>();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -37,14 +40,6 @@ else
 {
     app.UseDeveloperExceptionPage();
     app.UseMigrationsEndPoint();
-}
-
-using (var scope = app.Services.CreateScope())
-{
-    var services = scope.ServiceProvider;
-    var context = services.GetRequiredService<CotdContext>();
-    //context.Database.EnsureCreated();
-    //DbInitializer.Initialize(context);
 }
 
 app.UseHttpsRedirection();

--- a/CotdQualifierRankWeb/Utils/LeaderboardQueueWorker.cs
+++ b/CotdQualifierRankWeb/Utils/LeaderboardQueueWorker.cs
@@ -1,0 +1,51 @@
+﻿using CotdQualifierRankWeb.Controllers;
+using CotdQualifierRankWeb.Services;
+
+namespace CotdQualifierRankWeb.Utils
+{
+    public class LeaderboardQueueWorker : IHostedService, IDisposable
+    {
+        private readonly IServiceProvider _services;
+        private Timer? _timer = null;
+
+        public LeaderboardQueueWorker(IServiceProvider services)
+        {
+            _services = services;
+        }
+
+        public Task StartAsync(CancellationToken stoppingToken)
+        {
+            Console.WriteLine("LeaderboardQueueWorker running.");
+            _timer = new Timer(DoWork, null, TimeSpan.Zero, TimeSpan.FromSeconds(2));
+
+            return Task.CompletedTask;
+        }
+
+        private async void DoWork(object? state)
+        {
+            using (var scope = _services.CreateScope())
+            {
+                var nadeoApiController = scope.ServiceProvider.GetRequiredService<NadeoApiController>();
+                var competitionService = scope.ServiceProvider.GetRequiredService<CompetitionService>();
+                var nadeoCompetitionService = scope.ServiceProvider.GetRequiredService<NadeoCompetitionService>();
+
+                var queueService = new QueueService(nadeoApiController, nadeoCompetitionService, competitionService);
+                await queueService.ProcessMapsAsync();
+            }
+        }
+
+        public Task StopAsync(CancellationToken stoppingToken)
+        {
+            Console.WriteLine("LeaderboardQueueWorker stopping.");
+
+            _timer?.Change(Timeout.Infinite, 0);
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+        }
+    }
+}

--- a/CotdQualifierRankWeb/Utils/QueueService.cs
+++ b/CotdQualifierRankWeb/Utils/QueueService.cs
@@ -1,0 +1,205 @@
+﻿using CotdQualifierRankWeb.Controllers;
+using CotdQualifierRankWeb.DTOs;
+using CotdQualifierRankWeb.Models;
+using CotdQualifierRankWeb.Services;
+using Newtonsoft.Json;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace CotdQualifierRankWeb.Utils
+{
+    public class QueueService
+    {
+        private static readonly Queue<string> MapLeaderboardsToFetch = new Queue<string>();
+        public static bool IsProcessing { get; private set; } = false;
+
+        NadeoApiController _nadeoApiController { get; set; }
+        NadeoCompetitionService _nadeoCompeitionService { get; set; }
+        CompetitionService _competitionService { get; set; }
+
+        public QueueService(NadeoApiController nadeoApiController, NadeoCompetitionService nadeoCompetitionService, CompetitionService competitionService)
+        {
+            _nadeoApiController = nadeoApiController;
+            _nadeoCompeitionService = nadeoCompetitionService;
+            _competitionService = competitionService;
+        }
+
+        public static void AddToQueue(string mapUid)
+        {
+            QueueService.MapLeaderboardsToFetch.Enqueue(mapUid);
+        }
+
+        public static bool QueueContains(string mapUid)
+        {
+            return QueueService.MapLeaderboardsToFetch.Contains(mapUid);
+        }
+
+        public async Task ProcessMapsAsync()
+        {
+            if (QueueService.MapLeaderboardsToFetch.Count == 0)
+            {
+                IsProcessing = false;
+                return;
+            }
+            if (IsProcessing)
+            {
+                return;
+            }
+
+            IsProcessing = true;
+            while (QueueService.MapLeaderboardsToFetch.Count > 0)
+            {
+                var mapUid = QueueService.MapLeaderboardsToFetch.Peek();
+                await FetchCompetitionFromNadeo(mapUid);
+                QueueService.MapLeaderboardsToFetch.Dequeue();
+            }
+            IsProcessing = false;
+        }
+
+        public async Task<Competition?> FetchCompetitionFromNadeo(string mapUid)
+        {
+            // get map totd info from nadeo
+            var mapResponse = await _nadeoApiController.GetTodtInfoForMap(mapUid);
+            if (mapResponse is not null)
+            {
+                var result = await mapResponse.Content.ReadAsStringAsync();
+                // get date of totd from response
+                try
+                {
+                    var mapTotdInfo = JsonConvert.DeserializeObject<NadeoMapTotdInfoDTO>(result);
+
+                    if (mapTotdInfo is null || mapTotdInfo.TotdMaps is null)
+                    {
+                        return null;
+                    }
+                    var dayOfWeek = (mapTotdInfo.TotdMaps.IndexOf(mapUid) + 1) % 7;
+                    var mapTotdDate = ISOWeek.ToDateTime(mapTotdInfo.TotdYear, mapTotdInfo.Week, (DayOfWeek)dayOfWeek);
+                    mapTotdDate = mapTotdDate.AddHours(19);
+
+                    if (mapTotdDate < new DateTime(2020, 11, 16))
+                    {
+                        return null;
+                    }
+
+                    // Check if we have a nadeocompetition with that date
+                    // If the competition name is null, we set the date to 2020-07-01 so that we will never find a match
+                    var nadeoCompetition = _nadeoCompeitionService
+                        .GetNadeoCompetitions()
+                        .FirstOrDefault(
+                            comp => NadeoCompetition.ParseDate(
+                                comp.Name is null ? "2020-07-01" : comp.Name
+                                ).Date == mapTotdDate.Date);
+
+                    Competition? cotd = null;
+                    if (nadeoCompetition is not null)
+                    {
+                        cotd = await FetchCompetition(nadeoCompetition, mapUid, mapTotdDate);
+                    }
+                    else
+                    {
+                        // If not, fetch competitions from Nadeo until we find a match
+                        nadeoCompetition = await FetchNadeoCompetition(mapUid, mapTotdDate);
+                        // When we find it, fetch the leaderboard and store it in the db
+                        if (nadeoCompetition is null)
+                        {
+                            return null;
+                        }
+                        cotd = await FetchCompetition(nadeoCompetition, mapUid, mapTotdDate);
+                    }
+                    return cotd;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e.Message);
+                    return null;
+                }
+            }
+            return null;
+        }
+
+        public async Task<List<Record>> FetchQualificationLeaderboard(NadeoCompetition nadeoCompetition, int challengeId)
+        {
+            // Fetch the qualification leaderboard
+            var fullLeaderboard = new List<Record>();
+
+            for (int i = 0; i < nadeoCompetition.NbPlayers; i += 100)
+            {
+                var leaderboardFragment = await _nadeoApiController.GetLeaderboard(challengeId, 100, i);
+
+                if (leaderboardFragment is not null && leaderboardFragment.Results is not null)
+                {
+                    var records = leaderboardFragment.Results.Select(entry => new Record { Time = entry.Score }).ToList();
+                    fullLeaderboard.AddRange(records);
+                }
+            }
+            return fullLeaderboard;
+        }
+
+        public async Task<Competition> FetchCompetition(NadeoCompetition nadeoCompetition, string mapUid, DateTime mapTotdDate)
+        {
+            var newCompetition = new Competition();
+            newCompetition.NadeoCompetitionId = nadeoCompetition.Id;
+            newCompetition.NadeoChallengeId = await _nadeoApiController.GetChallengeId(nadeoCompetition.Id);
+            newCompetition.NadeoMapUid = mapUid;
+            newCompetition.Date = mapTotdDate;
+            newCompetition.Leaderboard = await FetchQualificationLeaderboard(nadeoCompetition, newCompetition.NadeoChallengeId);
+            _competitionService.AddCompetition(newCompetition);
+
+            return newCompetition;
+        }
+
+        public async Task<NadeoCompetition?> FetchNadeoCompetition(string mapUid, DateTime mapTotdDate)
+        {
+            var offsetLimit = 10000;
+            int offset = 0;
+            while (offset < offsetLimit)
+            {
+                var compResponse = await _nadeoApiController.GetCompetitions(100, offset);
+                if (compResponse is not null)
+                {
+                    var compResult = await compResponse.Content.ReadAsStringAsync();
+                    try
+                    {
+                        var competitions = JsonConvert.DeserializeObject<List<NadeoCompetition>>(compResult);
+                        if (competitions is null)
+                        {
+                            return null;
+                        }
+                        if (offset == 0)
+                        {
+                            offsetLimit = competitions.First().Id;
+                        }
+
+
+                        //var cotdCompetitions = competitions.Where(comp => Regex.IsMatch(comp.Name is null ? "" : comp.Name, @"COTD 20[0-9][0-9]-[0-9][0-9]-[0-9][0-9] #1$")).ToList();
+                        var cotdCompetitions = competitions.Where(comp => Regex.IsMatch(comp.Name is null ? "" : comp.Name, @"(COTD|Cup of the Day) 20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]($| #1$)")).ToList();
+
+                        // store all competitions while searching
+                        _nadeoCompeitionService.AddNadeoCompetitions(cotdCompetitions);
+
+                        // Check if we have a nadeocompetition with that date
+                        // If the competition name is null, we set the date to 2020-07-01 so that we will never find a match
+                        var competition = cotdCompetitions
+                                .FirstOrDefault(
+                                    comp => NadeoCompetition.ParseDate(
+                                        comp.Name is null ? "2020-07-01" : comp.Name
+                                        ).Date == mapTotdDate.Date);
+
+                        // when we find it, fetch the leaderboard and store it in the db
+                        if (competition is not null)
+                        {
+                            return competition;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e.Message);
+                        return null;
+                    }
+                }
+                offset += 100;
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Closes #35 

- Add queue system for fetching leaderboards when corresponding competition leaderboard is not stored in the database.
  - Requesting rank for a map whose leaderboard is not yet fetched from Nadeo causes the map to be added to a queue to be fetched later. Every two seconds, a hosted service checks if the queue has contents. Each map in the queue is then processed and dequeued. This allows multiple users to send requests to the same or different maps simultaneously. Map fetching is handled on a first-come-first-serve basis.