### PR TITLE
Add regex validation of mapUid

### DIFF
--- a/CotdQualifierRankWeb/Models/Competition.cs
+++ b/CotdQualifierRankWeb/Models/Competition.cs
@@ -4,6 +4,8 @@ namespace CotdQualifierRankWeb.Models
 {
     public class Competition
     {
+        public static string MapPattern = @"^[A-Za-z0-9_]{26,27}$";
+
         public int Id { get; set; }
 
         [Display(Name = "Competition ID")]

--- a/CotdQualifierRankWeb/Utils/QueueService.cs
+++ b/CotdQualifierRankWeb/Utils/QueueService.cs
@@ -58,7 +58,11 @@ namespace CotdQualifierRankWeb.Utils
 
         public async Task<Competition?> FetchCompetitionFromNadeo(string mapUid)
         {
-            // get map totd info from nadeo
+            // check if mapUid matches pattern
+            if (!Regex.IsMatch(mapUid, Competition.MapPattern))
+            {
+                return null;
+            }
             var mapResponse = await _nadeoApiController.GetTodtInfoForMap(mapUid);
             if (mapResponse is not null)
             {
@@ -68,10 +72,14 @@ namespace CotdQualifierRankWeb.Utils
                 {
                     var mapTotdInfo = JsonConvert.DeserializeObject<NadeoMapTotdInfoDTO>(result);
 
-                    if (mapTotdInfo is null || mapTotdInfo.TotdMaps is null)
+                    // Response is null or empty or map is not TOTD
+                    if (mapTotdInfo is null ||
+                        mapTotdInfo.TotdMaps is null ||
+                        mapTotdInfo.TotdYear == -1)
                     {
                         return null;
                     }
+
                     var dayOfWeek = (mapTotdInfo.TotdMaps.IndexOf(mapUid) + 1) % 7;
                     var mapTotdDate = ISOWeek.ToDateTime(mapTotdInfo.TotdYear, mapTotdInfo.Week, (DayOfWeek)dayOfWeek);
                     mapTotdDate = mapTotdDate.AddHours(19);


### PR DESCRIPTION
Closes #42 

Add regex validation on Rank endpoint. This avoids fetching campagin data from Nadeo when mapUid does not match expected pattern.